### PR TITLE
Add a tag extension <jira> to support JQL

### DIFF
--- a/JIRAConnector.body.php
+++ b/JIRAConnector.body.php
@@ -31,7 +31,7 @@ class JIRAConnector {
 		
 		//Map parser function ReadJIRAIssue to the magic word readjiraissue.
 		$parser->setFunctionHook( 'readjiraissue', 'JIRAConnector::RenderJIRAIssueStatus' );
-		$parser->setHook( 'jira', 'JIRAConnector::RenderJQL');
+		$parser->setHook( 'jira', 'JIRAConnector::RenderJIRAIssues');
 		
 		// Return true so that MediaWiki continues to load extensions.
 		return true;
@@ -83,7 +83,7 @@ class JIRAConnector {
 	 * @param unknown $parser
 	 * @return multitype:boolean string
 	 */
-	public static function RenderJQL( $text, array $args, Parser $parser, PPFrame $frame ) {
+	public static function RenderJIRAIssues( $text, array $args, Parser $parser, PPFrame $frame ) {
 				
 		//Disable caching for this extension.
 		$parser->disableCache();
@@ -106,7 +106,11 @@ class JIRAConnector {
 			$issueStatus = $jiraIssue["fields"][JIRAConnector::JIRAIssueStatus]["name"];
 			$issueTypeIcon = $jiraIssue["fields"][JIRAConnector::JIRAIssueType]["iconUrl"];
 			$summary = $jiraIssue["fields"][JIRAConnector::JIRAIssueSummary];
-			$output .= "<tr><td><img src=\"$issueTypeIcon\"/></td><td><a href=\"$issueURL\">$issueKey</a></td><td>$summary</td></tr>";
+			$output .= "<tr>";
+			$output .= "<td><img src=\"$issueTypeIcon\"/></td>";
+			$output .= "<td><a href=\"$issueURL\">$issueKey</a></td>";
+			$output .= "<td>$summary</td>";
+			$output .= "</tr>";
 		}
 		$output .= "</tbody></table>";
 

--- a/JIRAConnector.body.php
+++ b/JIRAConnector.body.php
@@ -84,7 +84,9 @@ class JIRAConnector {
 	 * @return multitype:boolean string
 	 */
 	public static function RenderJIRAIssues( $text, array $args, Parser $parser, PPFrame $frame ) {
-				
+		
+		global $jiraURL;		
+
 		//Disable caching for this extension.
 		$parser->disableCache();
 		
@@ -108,7 +110,7 @@ class JIRAConnector {
 			$summary = $jiraIssue["fields"][JIRAConnector::JIRAIssueSummary];
 			$output .= "<tr>";
 			$output .= "<td><img src=\"$issueTypeIcon\"/></td>";
-			$output .= "<td><a href=\"$issueURL\">";
+			$output .= "<td><a href=\"$jiraURL/browse/$issueKey\">";
 			if ($issueStatus == "Resolved") {
 				$output .= "<strike>"	;
 			}

--- a/JIRAConnector.body.php
+++ b/JIRAConnector.body.php
@@ -30,8 +30,8 @@ class JIRAConnector {
 		JIRAConnector::$jiraWrapper = new JIRARestApiWrapper($jiraURL,$jiraUsername,$jiraPassword);
 		
 		//Map parser function ReadJIRAIssue to the magic word readjiraissue.
-		$parser->setFunctionHook( 'readjiraissue', 'JIRAConnector::ReadJIRAIssue' );
-		$parser->setHook( 'jira', 'JIRAConnector::ExecuteJQL');
+		$parser->setFunctionHook( 'readjiraissue', 'JIRAConnector::RenderJIRAIssueStatus' );
+		$parser->setHook( 'jira', 'JIRAConnector::RenderJQL');
 		
 		// Return true so that MediaWiki continues to load extensions.
 		return true;
@@ -43,7 +43,7 @@ class JIRAConnector {
 	 * @param unknown $parser
 	 * @return multitype:boolean string
 	 */
-	public static function ReadJIRAIssue( $parser ) {
+	public static function RenderJIRAIssueStatus( $parser ) {
 				
 		//Disable caching for this extension.
 		$parser->disableCache();
@@ -83,7 +83,7 @@ class JIRAConnector {
 	 * @param unknown $parser
 	 * @return multitype:boolean string
 	 */
-	public static function ExecuteJQL( $text, array $args, Parser $parser, PPFrame $frame ) {
+	public static function RenderJQL( $text, array $args, Parser $parser, PPFrame $frame ) {
 				
 		//Disable caching for this extension.
 		$parser->disableCache();

--- a/JIRAConnector.body.php
+++ b/JIRAConnector.body.php
@@ -108,7 +108,15 @@ class JIRAConnector {
 			$summary = $jiraIssue["fields"][JIRAConnector::JIRAIssueSummary];
 			$output .= "<tr>";
 			$output .= "<td><img src=\"$issueTypeIcon\"/></td>";
-			$output .= "<td><a href=\"$issueURL\">$issueKey</a></td>";
+			$output .= "<td><a href=\"$issueURL\">";
+			if ($issueStatus == "Resolved") {
+				$output .= "<strike>"	;
+			}
+			$output .= $issueKey;
+			if ($issueStatus == "Resolved") {
+				$output .= "</strike>";
+			}
+			$output .= "</a></td>";
 			$output .= "<td>$summary</td>";
 			$output .= "</tr>";
 		}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Using the demo JIRA instance of Atlassian that you can find here: https://jira.a
 ### How to get a status of a JIRA issue "DEMO-1"
 Paste the following line to your wiki page:
 
-{{#readjiraissue:jiraissuekey=DEMO-1}}
+`{{#readjiraissue:jiraissuekey=DEMO-1}}`
 
 ### How to get a list of of resolved JIRA issues from the project DEMO
 Paste the following line to your wiki page:

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Navigate to "*Special:Version*" on your wiki to verify that the extension is suc
 
 Using the demo JIRA instance of Atlassian that you can find here: https://jira.atlassian.com
 
-# How to get a status of a JIRA issue "DEMO-1"
+### How to get a status of a JIRA issue "DEMO-1"
 Paste the following line to your wiki page:
 
 {{#readjiraissue:jiraissuekey=DEMO-1}}
 
-# How to get a list of of resolved JIRA issues from the project DEMO
+### How to get a list of of resolved JIRA issues from the project DEMO
 Paste the following line to your wiki page:
 
 `<jira>project=DEMO and status=Resolved</jira>`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The extension provides:
 * a tag extension to retrieve a list of JIRA issues using JQL: 
 `<jira>project=DEMO and status=Resolved</jira>`
 
-# Installation
+## Installation
 Download and extract the file(s) in a directory called JIRAConnector in your `extensions/` folder. 
 
 Add the following code at the bottom of your `LocalSettings.php`:
@@ -27,7 +27,16 @@ Done!
 
 Navigate to "*Special:Version*" on your wiki to verify that the extension is successfully installed.
 
-# Usage
-How to get a status of a JIRA issue "DEMO-1"
-Paste the following code to a wiki page and change the JIRA issue key to a valid key of your JIRA programm:
+## Usage
+
+Using the demo JIRA instance of Atlassian that you can find here: https://jira.atlassian.com
+
+# How to get a status of a JIRA issue "DEMO-1"
+Paste the following line to your wiki page:
+
 {{#readjiraissue:jiraissuekey=DEMO-1}}
+
+# How to get a list of of resolved JIRA issues from the project DEMO
+Paste the following line to your wiki page:
+
+`<jira>project=DEMO and status=Resolved</jira>`

--- a/README.md
+++ b/README.md
@@ -2,3 +2,26 @@ JIRAConnectorExtension
 ======================
 
 This extension can be used to request data from JIRA and transfer it to MediaWiki. It uses the new JIRA REST API.
+
+# Installation
+Download and extract the file(s) in a directory called JIRAConnector in your `extensions/` folder. 
+
+Add the following code at the bottom of your `LocalSettings.php`:
+```php
+require_once "$IP/extensions/JIRAConnector/JIRAConnector.php";
+$jiraURL="https://jira.atlassian.com";
+$jiraUsername="a username";
+$jiraPassword="a password";
+# For anonymous access to your JIRA instance comment the above two lines and
+# replace by the following two
+#$jiraUsername=NULL;
+#$jiraPassword=NULL;
+```
+Done! 
+
+Navigate to "*Special:Version*" on your wiki to verify that the extension is successfully installed.
+
+# Usage
+How to get a status of a JIRA issue "DEMO-1"
+Paste the following code to a wiki page and change the JIRA issue key to a valid key of your JIRA programm:
+{{#readjiraissue:jiraissuekey=DEMO-1}}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 JIRAConnectorExtension
 ======================
 
-This extension can be used to request data from JIRA and transfer it to MediaWiki. It uses the new JIRA REST API.
+This extension can be used to request data from JIRA and transfer it to MediaWiki. It uses the new JIRA REST API `/rest/api/2/search`.
+
+The extension provides:
+* a parser function extension to retrieve the status of a JIRA issue: `{{#readjiraissue:jiraissuekey=DEMO-1}}`
+* a tag extension to retrieve a list of JIRA issues using JQL: `<jira>project=DEMO and status=Resolved</jira>`
 
 # Installation
 Download and extract the file(s) in a directory called JIRAConnector in your `extensions/` folder. 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ JIRAConnectorExtension
 This extension can be used to request data from JIRA and transfer it to MediaWiki. It uses the new JIRA REST API `/rest/api/2/search`.
 
 The extension provides:
-* a parser function extension to retrieve the status of a JIRA issue: `{{#readjiraissue:jiraissuekey=DEMO-1}}`
-* a tag extension to retrieve a list of JIRA issues using JQL: `<jira>project=DEMO and status=Resolved</jira>`
+* a parser function extension to retrieve the status of a JIRA issue: 
+`{{#readjiraissue:jiraissuekey=DEMO-1}}`
+* a tag extension to retrieve a list of JIRA issues using JQL: 
+`<jira>project=DEMO and status=Resolved</jira>`
 
 # Installation
 Download and extract the file(s) in a directory called JIRAConnector in your `extensions/` folder. 


### PR DESCRIPTION
In order to keep backwards compatibility I added a tag extension `<jira>` next to the existing parser function `{{#readjiraissue}}`.

The tag extension takes a JQL as PCDATA and renders the retrieved list of JIRA issues as a table. If an issue has the _Resolved_ status, the issue key is rendered with a strike through. 
I took the way **Confluence** wiki renders JIRA issues as an example.

I've also updated the README.md with the information found on the extension homepage on mediawiki.org: http://www.mediawiki.org/wiki/Extension:JIRAConnector. And added the some describtion about the new tag extension.
